### PR TITLE
Add colors to address bar

### DIFF
--- a/JSBrowser/css/browser.css
+++ b/JSBrowser/css/browser.css
@@ -47,6 +47,7 @@ html {
     top: 0;
     left: 0;
     z-index: 2;
+    padding-right: 35px;
 }
 
 #urlInput {
@@ -72,7 +73,6 @@ html {
     border-color:  transparent;
     white-space: nowrap;
     overflow: hidden;
-    padding-right: 35px;
 }
 #urlDisplay .https {
     color: #090;

--- a/JSBrowser/css/browser.css
+++ b/JSBrowser/css/browser.css
@@ -24,32 +24,76 @@ html {
 .fullscreen .navbar {
     display: none;
 }
-
-#urlInput {
+#urlWrap {
+    position: relative;
     margin: 0 0 0 4px;
-    border-radius: 3px;
     height: 32px;
     flex-grow: 1;
-    background-color: #eee;
-    color: #666;
+    padding-right: 35px;
+}
+
+#urlWrap > * {
+    height: 100%;
+    border-radius: 3px;
     font-family: 'Segoe UI', sans-serif;
     font-size: 15px;
     font-weight: 400;
     line-height: 1.333;
-    padding: 3px 35px 5px 35px;
-    border-style: solid;
-    border-width: 2px;
-    border-color: rgba(255, 255, 255, 0.4);
+    padding-top: 3px;
+    padding-bottom: 5px;
+    padding-left: 35px;
+    border: 2px solid;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
 }
 
+#urlInput {
+    width: 100%;
+    color: transparent;
+    z-index: 1;
+    border-color: rgba(255, 255, 255, 0.4);
+    background-color: #eee;
+}
 #urlInput:focus {
     border-color: #0078D7;
+    color: #666;
+}
+#urlInput:focus + #urlDisplay {
+    display: none;
 }
 
-#urlInput:hover,
+#urlDisplay {
+    width: calc(100% - 35px);
+    color: #777;
+    z-index: 2;
+    pointer-events: none;
+    border-color:  transparent;
+    white-space: nowrap;
+    overflow: hidden;
+    padding-right: 35px;
+}
+#urlDisplay .https {
+    color: #090;
+}
+#urlDisplay .domain {
+    color: #000 !important;
+}
+#urlDisplay:after {
+    display: block;
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 5%;
+    background-image: linear-gradient(to right, rgba(238,238,238,0) 0%, rgba(238,238,238,1) 100%);
+}
+
 #urlInput:focus,
-.icon:hover ~ #urlInput,
-#tweet:hover ~ #urlInput {
+.icon:hover ~ #urlDisplay,
+#tweet:hover ~ #urlDisplay {
     background-color: #fff;
     color: #222;
 }
@@ -65,6 +109,7 @@ html {
     top: 10px;
     left: 115px;
     cursor: text;
+    z-index: 3;
 }
 
 .icon img {
@@ -91,6 +136,7 @@ html {
     position: absolute;
     top: 10px;
     right: 82px;
+    z-index: 3;
     width: 20px;
     height: 20px;
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAAA5FBMVEUAAAD1+v9ar+51vPLk8vz0+v7P6PtKp+1Zru5csO9yu/Frt/Bqt/B9wPKJxfOJxfOWzPWk0/an1Paq1vbA4Pm+3/m/4PjI5Pnj8v3o9P1dsO9Eo+xRqu5dsO9Zru5hsu9fse9esO93vfF3vPFltPBmtPCczvV4vfKn1PZdsO+AwfJis++YzfRvuPGFxPOu1/e63fiw2feg0fXZ7Pve7/zS6fvI5Pnn8/z3+/7e7/z9/v9VrO5Xre45n+tQqu5MqO1Hpu1Do+xYru5Oqe00nOtTq+4ym+sumeo9oewrmOollekgkuij5K+8AAAAO3RSTlMADe/VJwcH/Pjv4uDVurCkmZKHcWlfWlAtFPv7+fbo5OPQzcW+vaelm5ualpGNf3tza2pHPzs1IxgLA03KNI0AAADRSURBVBjTncxFssJQFEXRE8Hd4bu74vA8isx/PuQFCS0arLqtXacuzvP//NQAJmOgWdu3h6WUoVWxbOB1/btttRUlxFHssQV8MK9k65iTRMvku8DAI0yW2z3cuLq5fAak5i+XhLMFzV9zHcVFOorV+6yvF9KnOqoCIp0VpyTBytDemEgq9ZqIfZnuISonFTejoJLh8g9bw0ywe+sEFg5apoh3gWlAS0c3ql7xKImwOEXMrt+pkBFfLDxRx57RrhRzTva21OjhSLf//f750zFw0gYUQyoqC9iHlgAAAABJRU5ErkJggg==);

--- a/JSBrowser/css/browser.css
+++ b/JSBrowser/css/browser.css
@@ -78,7 +78,10 @@ html {
     color: #090;
 }
 #urlDisplay .domain {
-    color: #000 !important;
+    color: #000;
+}
+#urlDisplay .login {
+    color: #006;
 }
 #urlDisplay:after {
     display: block;

--- a/JSBrowser/default.html
+++ b/JSBrowser/default.html
@@ -29,7 +29,10 @@
                         <img id="favicon" src="" />
                     </label>
                     <div id="tweet" title="Tweet about this browser"></div>
-                    <input id="urlInput" type="text" class="win-textbox" />
+                    <div id="urlWrap">
+                        <input id="urlInput" type="text" class="win-textbox" />
+                        <span id="urlDisplay" class="win-textbox" />
+                    </div>
                     <button id="favButton" class="navButton favButton" title="View favorites"></button>
                     <button id="settingsButton" class="navButton settingsButton" title="View settings"></button>
                 </div>

--- a/JSBrowser/js/browser.js
+++ b/JSBrowser/js/browser.js
@@ -83,6 +83,7 @@
             "stopButton": document.querySelector("#stopButton"),
             "tweetIcon": document.querySelector("#tweet"),
             "urlInput": document.querySelector("#urlInput"),
+            "urlDisplay": document.querySelector("#urlDisplay"),
             "webview": document.querySelector("#WebView")
         });
 

--- a/JSBrowser/js/components/address-bar.js
+++ b/JSBrowser/js/components/address-bar.js
@@ -147,9 +147,41 @@
         style.display = isHidden ? "inline-block" : "none";
     };
 
+    this.colorizeAddress = address => {
+        let HTML = '';
+        // Parse URL using an <a> element
+        let a = document.createElement('a');
+        a.href = address;
+
+        // Detect HTTPS protocol
+        if (a.protocol === 'https:')
+            HTML += "<span class='https'>https:</span>//";
+        // Display any protocol other than HTTP
+        else if (a.protocol !== 'http:')
+            HTML += a.protocol + "//";
+
+        // Highlight domain in hostname
+        let hostnameRegex = /(^|\.)([^.]+(?:\.[\w\d]{2,3})?\.[\w\d]{2,})$/;
+        HTML += hostnameRegex.test(a.hostname)
+            ? a.hostname.replace(hostnameRegex, "$1<span class='domain'>$2</span>")
+            : "<span class='domain'>" + a.hostname + "</span>";
+
+        // Add port if it's a valid number
+        if (a.port.length > 0 && !isNaN(a.port))
+            HTML += ':' + a.port;
+
+        // Remove last / from pathname if original address doesn't have it either
+        let pathname = a.pathname;
+        if (/\/$/.test(address))
+            pathname = pathname.replace(/\/$/, '');
+        HTML += pathname+a.search+a.hash;
+        return HTML;
+    }
+
     // Update the address bar with the given text and remove focus
     this.updateAddressBar = text => {
         this.urlInput.value = text;
+        this.urlDisplay.innerHTML = this.colorizeAddress(text);
         this.urlInput.blur();
     };
 

--- a/JSBrowser/js/components/address-bar.js
+++ b/JSBrowser/js/components/address-bar.js
@@ -172,7 +172,7 @@
 
         // Remove last / from pathname if original address doesn't have it either
         let pathname = a.pathname;
-        if (/\/$/.test(address))
+        if (!/\/$/.test(address))
             pathname = pathname.replace(/\/$/, '');
         HTML += pathname+a.search+a.hash;
         return HTML;

--- a/JSBrowser/js/components/address-bar.js
+++ b/JSBrowser/js/components/address-bar.js
@@ -139,38 +139,46 @@
 
     this.colorizeAddress = address => {
         let HTML = '';
-        // Parse URL using an <a> element
-        let a = document.createElement('a');
-        a.href = address;
+        // Parse URL
+        let a = new URI(address);
 
         // Detect HTTPS protocol
-        if (a.protocol === 'https:')
+        if (a.schemeName === 'https')
             HTML += "<span class='https'>https:</span>//";
         // Display any protocol other than HTTP
-        else if (a.protocol !== 'http:')
-            HTML += a.protocol + "//";
+        else if (a.schemeName !== 'http')
+            HTML += a.schemeName + "://";
+
+        // Add Username & password if applicable
+        if (a.userName)
+            HTML += "<span class='login'>"+a.userName + (a.password ? ":"+a.password : '') + "</span>@";
 
         // Highlight domain in hostname
         let hostnameRegex = /(^|\.)([^.]+(?:\.[\w\d]{2,3})?\.[\w\d]{2,})$/;
-        HTML += hostnameRegex.test(a.hostname)
-            ? a.hostname.replace(hostnameRegex, "$1<span class='domain'>$2</span>")
-            : "<span class='domain'>" + a.hostname + "</span>";
+        HTML += hostnameRegex.test(a.host)
+            ? a.host.replace(hostnameRegex, "$1<span class='domain'>$2</span>")
+            : "<span class='domain'>" + a.host + "</span>";
 
         // Add port if it's a valid number
         if (a.port.length > 0 && !isNaN(a.port))
             HTML += ':' + a.port;
 
         // Remove last / from pathname if original address doesn't have it either
-        let pathname = a.pathname;
-        if (!/\/$/.test(address))
+        let pathname = a.path;
+        if (!address.endsWith('/'))
             pathname = pathname.replace(/\/$/, '');
-        HTML += pathname+a.search+a.hash;
+        HTML += pathname+a.query+a.fragment;
         return HTML;
+    }
+
+    // Remove HTTP protocol from URI
+    this.removeHTTPFromURI = uri => {
+        return uri.replace(/^http:\/\//, '');
     }
 
     // Update the address bar with the given text and remove focus
     this.updateAddressBar = text => {
-        this.urlInput.value = text;
+        this.urlInput.value = this.removeHTTPFromURI(text);
         this.urlDisplay.innerHTML = this.colorizeAddress(text);
         this.urlInput.blur();
     };

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ http://microsoftedge.github.io/JSBrowser/
 
 [![badge_windowsstore](https://cloud.githubusercontent.com/assets/7266075/9445327/6a0e1d9e-4a40-11e5-80e9-99b21af35c35.png)](https://www.microsoft.com/store/apps/9NBLGGH1Z7VX)
 
-![JavaScript Browser](https://cloud.githubusercontent.com/assets/7266075/9344225/df4d62ba-45bb-11e5-9d84-a078b8fd651a.png)
+![JavaScript Browser](https://cloud.githubusercontent.com/assets/3200580/10122615/99850d4a-651f-11e5-8357-e83576384010.png)
 
 This project is a proof-of-concept demonstrating the capabilities of the web platform on Windows 10. The browser is built around the HTML [WebView control](https://msdn.microsoft.com/en-us/library/windows/apps/dn301831.aspx), using primarily JavaScript to light up the user interface. Built using [Visual Studio 2015](https://www.visualstudio.com/), this is a JavaScript [Universal Windows Platform](https://msdn.microsoft.com/library/windows/apps/dn894631.aspx) (UWP) app.
 


### PR DESCRIPTION
This completes the following points of #6:

 - Auto truncation of `http:` protocol from address bar
 - URL highlighting (green for https, black for domain, dark gray for the rest)

Newly added JavaScript code is well-commented, address part colors are specified in `browser.css`