### PR TITLE
JavaScript Browser Chrome Edition

### DIFF
--- a/JSBrowser/css/browser.css
+++ b/JSBrowser/css/browser.css
@@ -1,4 +1,4 @@
-﻿*,
+*,
 *:before,
 *:after {
   box-sizing: inherit;
@@ -6,6 +6,12 @@
 
 html {
   box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    height: 100%;
+    overflow: hidden;
 }
 
 #browser {
@@ -282,6 +288,7 @@ html {
 }
 
 #WebView {
+    display: block;
     width: 100%;
     height: calc(100% - 40px);
 }

--- a/JSBrowser/default.html
+++ b/JSBrowser/default.html
@@ -1,20 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>JavaScript Browser</title>
-
-    <!-- App references -->
+    <title>JavaScript Browser Chrome Edition</title>
     <link href="css/browser.css" rel="stylesheet" />
-    <script src="js/browser.js"></script>
-
-    <!-- UI component references -->
-    <script src="js/components/webview.js"></script>
-    <script src="js/components/address-bar.js"></script>
-    <script src="js/components/navigation.js"></script>
-    <script src="js/components/favorites.js"></script>
-    <script src="js/components/settings.js"></script>
-    <script src="js/components/title-bar.js"></script>
 </head>
 <body>
     <div id="browser" class="perspective effect-moveleft">
@@ -36,7 +25,7 @@
                     <button id="favButton" class="navButton favButton" title="View favorites"></button>
                     <button id="settingsButton" class="navButton settingsButton" title="View settings"></button>
                 </div>
-                <x-ms-webview id="WebView"></x-ms-webview>
+                <webview id="WebView" partition="persist:jsbrowser"></webview>
             </div>
         </div>
         <nav id="favMenu" class="outer-nav right vertical">
@@ -59,5 +48,18 @@
         </nav>
     </div>
     <div id="fullscreenMessage">You are now in full screen mode. <a id="hideFullscreen">Click here</a> or press F11 to exit.</div>
+    <!-- WinRT shim -->
+    <script src="js/winrt.js"></script>
+    <!-- App references -->
+    <script src="js/browser.js"></script>
+    <!-- UI component references -->
+    <script src="js/components/webview.js"></script>
+    <script src="js/components/address-bar.js"></script>
+    <script src="js/components/navigation.js"></script>
+    <script src="js/components/favorites.js"></script>
+    <script src="js/components/settings.js"></script>
+    <script src="js/components/title-bar.js"></script>
+
+
 </body>
 </html>

--- a/JSBrowser/js/winrt.js
+++ b/JSBrowser/js/winrt.js
@@ -1,0 +1,201 @@
+/* Windows Runtime JS shim by Jerzy Głowacki. License: MIT */
+
+
+NWGui = require('nw.gui');
+
+Promise.prototype.done = Promise.prototype.then; // Promise.done is removed
+
+if (typeof setImmediate === "undefined") {
+	setImmediate = setTimeout; // setImmediate is IE/Edge only
+}
+
+if (typeof Proxy === "undefined") {
+	Proxy = function (target, object) { // Proxy will land in Chrome 49
+		return Object.assign(target, object);
+	};
+}
+
+if (typeof NativeListener === "undefined") {
+	NativeListener = {
+		KeyHandler: function () {} // Stub
+	};
+}
+
+if (typeof Windows === "undefined") {
+	Windows = {
+		Foundation: {
+			Uri: function (uri) {
+				var url = new URL(uri);
+				url.schemeName = url.protocol.slice(0, -1);
+				url.userName = url.username;
+				url.path = url.pathname;
+				url.query = url.search;
+				url.fragment = url.hash;
+				return url;
+			}
+		},
+		Storage: {
+			ApplicationData: {
+				current: {
+					roamingFolder: {
+						createFileAsync: function (file, option) {
+							return new Promise(function (resolve, reject) {
+								resolve(file);
+							});
+						},
+						getFileAsync: function (file) {
+							return new Promise(function (resolve, reject) {
+								resolve(file);
+							});
+						}
+					}
+				}
+			},
+			CreationCollisionOption: {
+				replaceExisting: 0
+			},
+			FileIO: {
+				readTextAsync: function (file) {
+					return new Promise(function (resolve, reject) {
+						resolve(localStorage.getItem(file));
+					});
+				},
+				writeTextAsync: function (file, contents) {
+					return new Promise(function (resolve, reject) {
+						resolve(localStorage.setItem(file, contents));
+					});
+				}
+			}
+		},
+		System: {
+			Launcher: {
+				launchURIAsync: function (url) {
+					NWGui.Shell.openExternal(url);
+				}
+			}
+		},
+		UI: {
+			ViewManagement: {
+				ApplicationView: {
+					getForCurrentView: function () {
+						return Object.assign(document.getElementById('browser'), {
+							isFullScreenMode: NWGui.Window.get().isFullscreen,
+							exitFullScreenMode: NWGui.Window.get().leaveFullscreen,
+							tryEnterFullScreenMode: NWGui.Window.get().enterFullscreen,
+							titleBar: {},
+						});
+					}
+				}
+			}
+		},
+		Web: {
+			Http: {
+				HttpClient: function () {
+					return {
+						getAsync: function (url, option) {
+							return new Promise(function (resolve, reject) {
+								var xhr = new XMLHttpRequest();
+								var method = (option === 0 ? 'HEAD' : 'GET');
+								xhr.open(method, url);
+								xhr.onload = function () {
+								      var isSuccessStatusCode = (this.status === 200 ? true : false);
+								      resolve({isSuccessStatusCode: isSuccessStatusCode});
+								};
+								xhr.onerror = function () {
+								      reject();
+								};
+								xhr.send();
+							});
+						}
+					};
+				},
+				HttpCompletionOption: {
+					responseHeadersRead: 0,
+					responseContentRead: 1
+				}
+			}
+		}
+	};
+}
+
+WebView = Object.assign(document.getElementById('WebView'), {
+	documentTitle: '',
+	navigate: function (url) {
+		this.src = url;
+	},
+	refresh: function () {
+		this.reload();
+	},
+	goBack: function () {
+		this.back();
+	},
+	goForward: function () {
+		this.forward();
+	},
+	addWebAllowedObject: function (name, obj) {},
+	invokeScriptAsync: function (fun, arg) {
+		var that = this;
+		return {
+			oncomplete: function () {},
+			onerror: function () {},
+			start: function () {
+				var that2 = this;
+				that.executeScript({code: arg}, function(results) {
+					if (results) {
+						that2.oncomplete({
+							target: {
+								result: results[0]
+							}
+						});
+					} else {
+						that2.onerror({
+							message: 'no result'
+						});
+					}
+				});
+			}
+		};
+	}
+});
+WebView.addEventListener('loadstart', function (e) {
+	console.log('loadstart', e);
+	if (e.isTopLevel) {
+		var msEvent = new Event('MSWebViewNavigationStarting');
+		msEvent.uri = e.url;
+		this.dispatchEvent(msEvent);
+	}
+});
+WebView.addEventListener('loadstop', function (e) {
+	console.log('loadstop', e);
+	var msEvent = new Event('MSWebViewNavigationCompleted');
+	msEvent.uri = e.target.src;
+	this.dispatchEvent(msEvent);
+});
+WebView.addEventListener('contentload', function (e) {
+	console.log('contentload', e);
+	var msEvent = new Event('MSWebViewDOMContentLoaded');
+	this.dispatchEvent(msEvent);
+});
+WebView.addEventListener('newwindow', function (e) {
+	console.log('newwindow', e);
+	var msEvent = new Event('MSWebViewNewWindowRequested');
+	msEvent.uri = e.url;
+	this.dispatchEvent(msEvent);
+});
+WebView.addEventListener('permissionrequest', function (e) {
+	console.log('permissionrequest', e);
+	var msEvent = new Event('MSWebViewPermissionRequested');
+	msEvent.permissionRequest = {
+		type: e.permission,
+		allow: e.request.allow
+	};
+	this.dispatchEvent(msEvent);
+});
+WebView.addEventListener('loadabort', function (e) {
+	console.log('loadabort', e);
+	if (e.reason === 'ERR_UNKNOWN_URL_SCHEME') {
+		var msEvent = new Event('MSWebViewUnsupportedURISchemeIdentified');
+		msEvent.message = e.url;
+		this.dispatchEvent(msEvent);
+	}
+});

--- a/JSBrowser/package.json
+++ b/JSBrowser/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "JavaScript Browser Chrome Edition",
+    "description": "A web browser built with JavaScript and NW.js as a cross-platform app",
+    "version": "1.2",
+    "author": "Microsoft WebApp Demos & Jerzy Głowacki",
+    "main": "default.html",
+    "window": {
+        "height": 600,
+        "width": 1024,
+        "show": true,
+        "title": "JavaScript Browser Chrome Edition",
+        "icon": "images/logo_44x44.png"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 #&nbsp;![Logo](https://cloud.githubusercontent.com/assets/7266075/9254929/15448684-419b-11e5-8110-41757c572fe8.png) JavaScript Browser Chrome Edition
-A web browser built with JavaScript &amp; NW.js as a cross-platform app. This is a fork of the [JavaScript Browser](http://microsoftedge.github.io/JSBrowser/) with Microsoft Edge WebView replaced with Google Chrome WebView, which works in Windows/Linux/OS X. This is a pre-release.<br />
+A web browser built with JavaScript &amp; NW.js as a cross-platform app. This is a fork of the [JavaScript Browser](http://microsoftedge.github.io/JSBrowser/) having Microsoft Edge WebView replaced with Google Chrome WebView, which works in Windows/Linux/OS X. This is a pre-release.<br />
 http://niutech.github.io/JSBrowser/
 
 ![JavaScript Browser Chrome Edition](http://i.imgur.com/SDFft2Y.png)
 
-This project is a tutorial demonstrating the capabilities of the web platform. The browser is a sample app built around the Chrome [WebView control](https://developer.chrome.com/apps/tags/webview), using primarily JavaScript to light up the user interface. Built using [Visual Studio 2015](https://www.visualstudio.com/) and [NW.js](http://nwjs.io/), this is a JavaScript app.
+This project is a tutorial demonstrating the capabilities of the web platform. The browser is a sample app built around the Chrome [WebView control](https://developer.chrome.com/apps/tags/webview), using primarily JavaScript to light up the user interface. Built using [Visual Studio 2015](https://www.visualstudio.com/) and [NW.js](http://nwjs.io/), this is a JavaScript app. In order to run it, download the latest NW.js v0.13 and drop the `JSBrowser` folder on the `nw.exe` app.
 
 In addition to JavaScript, HTML and CSS are the other core programming languages used. Some C++ code is also included to enable supplemental features, but is not required to create a simple browser.
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-#&nbsp;![Logo](https://cloud.githubusercontent.com/assets/7266075/9254929/15448684-419b-11e5-8110-41757c572fe8.png) JavaScript Browser
-A web browser built with JavaScript as a Windows app.<br />
-http://microsoftedge.github.io/JSBrowser/
+#&nbsp;![Logo](https://cloud.githubusercontent.com/assets/7266075/9254929/15448684-419b-11e5-8110-41757c572fe8.png) JavaScript Browser Chrome Edition
+A web browser built with JavaScript &amp; NW.js as a cross-platform app. This is a fork of the [JavaScript Browser](http://microsoftedge.github.io/JSBrowser/) with Microsoft Edge WebView replaced with Google Chrome WebView, which works in Windows/Linux/OS X. This is a pre-release.<br />
+http://niutech.github.io/JSBrowser/
 
-[![badge_windowsstore](https://cloud.githubusercontent.com/assets/7266075/9445327/6a0e1d9e-4a40-11e5-80e9-99b21af35c35.png)](https://www.microsoft.com/store/apps/9NBLGGH1Z7VX)
+![JavaScript Browser Chrome Edition](http://i.imgur.com/SDFft2Y.png)
 
-![JavaScript Browser](https://cloud.githubusercontent.com/assets/3200580/10122615/99850d4a-651f-11e5-8357-e83576384010.png)
-
-This project is a tutorial demonstrating the capabilities of the web platform on Windows 10. The browser is a sample app built around the HTML [WebView control](https://msdn.microsoft.com/en-us/library/windows/apps/dn301831.aspx), using primarily JavaScript to light up the user interface. Built using [Visual Studio 2015](https://www.visualstudio.com/), this is a JavaScript [Universal Windows Platform](https://msdn.microsoft.com/library/windows/apps/dn894631.aspx) (UWP) app.
+This project is a tutorial demonstrating the capabilities of the web platform. The browser is a sample app built around the Chrome [WebView control](https://developer.chrome.com/apps/tags/webview), using primarily JavaScript to light up the user interface. Built using [Visual Studio 2015](https://www.visualstudio.com/) and [NW.js](http://nwjs.io/), this is a JavaScript app.
 
 In addition to JavaScript, HTML and CSS are the other core programming languages used. Some C++ code is also included to enable supplemental features, but is not required to create a simple browser.
 
-Additionally, we’re taking advantage of the new [ECMAScript 2015](http://www.ecma-international.org/ecma-262/6.0/) (ES2015) support in Chakra, the JavaScript engine behind Microsoft Edge and the WebView control. ES2015 allows us to remove much of the scaffolding and boilerplate code, simplifying our implementation significantly. The following ES2015 features were used in the creation of this app: [Array.from()](http://www.ecma-international.org/ecma-262/6.0/#sec-array.from), [Array.prototype.find()](http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.find), [arrow functions](http://dev.modern.ie/platform/status/arrowfunction/), [method properties](http://dev.modern.ie/platform/status/es6objectliteralenhancements/), [const](http://dev.modern.ie/platform/status/blockbindingsletconstfunction/), [for-of](http://dev.modern.ie/platform/status/jsiteratorsietheforoffeature/), [let](http://dev.modern.ie/platform/status/blockbindingsletconstfunction/), [Map](http://dev.modern.ie/platform/status/map/), [Object.assign()](http://dev.modern.ie/platform/status/objectbuiltinses6/), [Promises](http://dev.modern.ie/platform/status/promiseses6/), [property shorthands](http://dev.modern.ie/platform/status/es6objectliteralenhancements/), [Proxies](http://dev.modern.ie/platform/status/proxieses6/), [spread operator](http://dev.modern.ie/platform/status/spreades6/), [String.prototype.includes()](http://dev.modern.ie/platform/status/stringbuiltinses6/), [String.prototype.startsWith()](http://dev.modern.ie/platform/status/stringbuiltinses6/), [Symbols](http://dev.modern.ie/platform/status/symbols/), [template strings](http://dev.modern.ie/platform/status/templatestringses6/), and [Unicode code point escapes](http://www.ecma-international.org/ecma-262/6.0/#sec-literals-string-literals).
+Additionally, we’re taking advantage of the new [ECMAScript 2015](http://www.ecma-international.org/ecma-262/6.0/) (ES2015) support in V8, the JavaScript engine behind Google Chrome and the WebView control. ES2015 allows us to remove much of the scaffolding and boilerplate code, simplifying our implementation significantly. The following ES2015 features were used in the creation of this app: [Array.from()](http://www.ecma-international.org/ecma-262/6.0/#sec-array.from), [Array.prototype.find()](http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.find), [arrow functions](http://dev.modern.ie/platform/status/arrowfunction/), [method properties](http://dev.modern.ie/platform/status/es6objectliteralenhancements/), [const](http://dev.modern.ie/platform/status/blockbindingsletconstfunction/), [for-of](http://dev.modern.ie/platform/status/jsiteratorsietheforoffeature/), [let](http://dev.modern.ie/platform/status/blockbindingsletconstfunction/), [Map](http://dev.modern.ie/platform/status/map/), [Object.assign()](http://dev.modern.ie/platform/status/objectbuiltinses6/), [Promises](http://dev.modern.ie/platform/status/promiseses6/), [property shorthands](http://dev.modern.ie/platform/status/es6objectliteralenhancements/), [Proxies](http://dev.modern.ie/platform/status/proxieses6/), [spread operator](http://dev.modern.ie/platform/status/spreades6/), [String.prototype.includes()](http://dev.modern.ie/platform/status/stringbuiltinses6/), [String.prototype.startsWith()](http://dev.modern.ie/platform/status/stringbuiltinses6/), [Symbols](http://dev.modern.ie/platform/status/symbols/), [template strings](http://dev.modern.ie/platform/status/templatestringses6/), and [Unicode code point escapes](http://www.ecma-international.org/ecma-262/6.0/#sec-literals-string-literals).
 
 ## User interface
 The user interface consists of ten components:
@@ -29,7 +27,7 @@ The user interface consists of ten components:
 
 ## Additional functionality
 There are several additional features implemented to make the browsing experience more pleasant:
-* Keyboard shortcuts - press F11 to toggle fullscreen mode, ESC to exit fullscreen mode, or Ctrl + L to select the address bar
+* <s>Keyboard shortcuts - press F11 to toggle fullscreen mode, ESC to exit fullscreen mode, or Ctrl + L to select the address bar</s> not working yet
 * [CSS transitions](http://www.w3.org/TR/css3-transitions/) for animating the menus
 * Cache management
 * Favorites management
@@ -42,17 +40,15 @@ There are several additional features implemented to make the browsing experienc
 <div class="navbar">
   <!-- ... -->
 </div>
-<x-ms-webview id="WebView"></x-ms-webview>
+<webview id="WebView" partition="persist:jsbrowser"></webview>
 ```
 
-[Introduced](http://blogs.windows.com/buildingapps/2013/07/17/whats-new-in-webview-in-windows-8-1/) for JavaScript apps in Windows 8.1, the WebView control—sometimes referred to by its tag name, [x-ms-webview](https://msdn.microsoft.com/en-us/library/windows/apps/dn301831.aspx)—allows you to host web content in your Windows app. Available in both HTML and [XAML](https://en.wikipedia.org/wiki/Extensible_Application_Markup_Language), the x-ms-webview comes with a powerful set of APIs, which overcomes [several of the limitations](http://blogs.windows.com/buildingapps/2013/10/01/blending-apps-and-sites-with-the-html-x-ms-webview/) that encumber an iframe, such as framebusting sites and document loading events. Additionally, the x-ms-webview provides new functionality that is not possible with an iframe, such as better access to local content and the ability to take screenshots.
-
-When you use the WebView control, you get the same web platform that powers Microsoft Edge.
+When you use the WebView control, you get the same web platform that powers Google Chrome.
 
 ![WebView flowchart](https://cloud.githubusercontent.com/assets/7266075/9342671/036d5e70-45b2-11e5-8f01-005dac0f644f.png)
 
 ## Developing the browser
-We will be using fifteen of the x-ms-webview APIs. All but two of these members handle the page navigation in some capacity. Let’s see how we can hook into these APIs to create each UI component.
+We will be using fifteen of the WebView APIs. All but two of these members handle the page navigation in some capacity. Let’s see how we can hook into these APIs to create each UI component.
 
 ### Hooking up the back and forward buttons
 When you invoke a back button, the browser returns to an earlier page in the browser history, if available. Similarly, when you invoke a forward button, the browser returns to a later page in the browser history, if available. In order to implement this logic, we use the [goBack()](https://msdn.microsoft.com/en-us/library/windows/apps/dn301838.aspx) and [goForward()](https://msdn.microsoft.com/en-us/library/windows/apps/dn301839.aspx) methods, respectively. These functions will automatically navigate to the correct page in the navigation stack.


### PR DESCRIPTION
I did a cross-platform version of your JS Browser last night, based on Chrome WebView. With minimal changes to your code, I added a Windows Runtime JS shim and made it work with the latest NW.js v0.13. Just download NW.js and drop the folder on it in order to run it. It works generally fine, except for the fullscreen mode and keyboard shortcuts, but it still needs thorough testing. JS Browser Chrome Edition scores excellent 526 points out of 555 in HTML5 Test!

What do you think? Would you like to help me develop it further?