### PR TITLE
Fix h1 rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#&nbsp;![Logo](https://cloud.githubusercontent.com/assets/7266075/9254929/15448684-419b-11e5-8110-41757c572fe8.png) JavaScript Browser
+# ![Logo](https://cloud.githubusercontent.com/assets/7266075/9254929/15448684-419b-11e5-8110-41757c572fe8.png) JavaScript Browser
 A web browser built with JavaScript as a Windows app.<br />
 http://microsoftedge.github.io/JSBrowser/
 


### PR DESCRIPTION
There's a minor bug in the README markdown that's preventing the headline from rendering properly.